### PR TITLE
Übungschef Woche 6

### DIFF
--- a/docs/project/requirements.md
+++ b/docs/project/requirements.md
@@ -16,8 +16,8 @@ Kopieren Sie das [Pflichtenheft Markdown Template](https://raw.githubusercontent
 
 Schauen Sie sich die Theorie zum Thema [Anforderungsanalyse](../week6) nochmals genau an. Überlegen Sie sich wer ihre Stakeholder sind und wie diese von den Änderungen betroffen sind. Schauen Sie sich die nachfolgenden Beispiele für Pflichtenhefte an:
 
-* [Beispiel früheres Projekt](https://adam.unibas.ch/goto_adam_file_1480294_download.html)
-* [Beispiel nach Lehrbuch von Balzert](https://adam.unibas.ch/goto_adam_file_1474955_download.html).
+* [Beispiel früheres Projekt](https://adam.unibas.ch/goto_adam_file_1629482.html)
+* [Beispiel nach Lehrbuch von Balzert](https://adam.unibas.ch/goto_adam_file_1629483.html).
 
 
 Schreiben Sie nun die Abschnitte 1 - 2 im Pflichtenheft für ihr Projekt. Nachdem Sie die Abschnitte geschrieben haben, machen Sie mit den nachfolgenden Schritten weiter. 

--- a/docs/project/requirements.md
+++ b/docs/project/requirements.md
@@ -32,7 +32,7 @@ Als nächstes beschreiben Sie die funktionalen Anforderungen im entsprechenden A
 Zur Identifizierung der funktionalen Anforderungen sollten Sie die oben erstellten Use-cases verwenden. Ergänzen Sie ihr Pflichtenheft mit den Anforderungen. 
 
 
-*Tipp: Falls viele von Ihren Anforderungen die Benutzeroberfläche betreffen, hilft es neuen Gui Elementen bereits grafisch zu illustrieren. Sie können diese zum Beispiel mit einem
+*Tipp: Falls viele von Ihren Anforderungen die Benutzeroberfläche betreffen, hilft es neue GUI Elemente bereits grafisch zu illustrieren. Sie können diese zum Beispiel mit einem
 Zeichenprogramm wie Inkscape oder Paint erstellen.*
 
 
@@ -42,7 +42,7 @@ Zeichenprogramm wie Inkscape oder Paint erstellen.*
 
 #### Offene Fragen an Betreuer und JabRef Entwickler
 
-Notieren Sie sich Unklarheiten und offene Fragen, die sie gerne mit Ihrem Betreuer diskutieren möchten direkt im Dokument. Kennzeichnen Sie diese klar mit dem Vermerk *OPEN QUESTION:* .
+Notieren Sie sich Unklarheiten und offene Fragen, die sie gerne mit Ihrem Betreuer diskutieren möchten, direkt im Dokument. Kennzeichnen Sie diese klar mit dem Vermerk *OPEN QUESTION:* .
 
 
 ## Projektplan
@@ -50,8 +50,7 @@ Notieren Sie sich Unklarheiten und offene Fragen, die sie gerne mit Ihrem Betreu
 Erstellen Sie nun anhand der Anforderungen einen Projektplan. Auf dem Plan sollen alle Tasks, die Sie zur Durchführung des Projekts bearbeiten müssen, aufgeführt sein. Für jede Task soll ersichtlich sein, wie lange diese dauert, wer diese bearbeitet und wann Sie mit der Bearbeitung beginnen
 können. Für so ein einfaches Projekt reicht, wenn Sie einfach eine Excel Tabelle oder ähnliches nutzen. In einem grösseren Projekt würde man dafür professionelle Projektmanagementsoftware verwenden. 
 
-Die Schätzung des Aufwands für eine Task ist schwierig. Je besser die funktionale Anforderungen spezifiziert sind, desto einfacher wird es aber, da wir den Aufwand für wohldefinierte Anforderung,
-relative kleine Tasks besser überblicken können. Natürlich hilft es auch sich mit dem Code auseinander zu setzen, um ein Gefühl für die Komplexität zu bekommen.
+Die Schätzung des Aufwands für eine Task ist schwierig. Je besser die funktionalen Anforderungen spezifiziert sind, desto einfacher wird es aber, da wohldefinierte Anforderungen zu konkreteren und dadurch besser überschaubaren Tasks übersetzt werden können. Natürlich hilft es auch sich mit dem Code auseinander zu setzen, um ein Gefühl für die Komplexität zu bekommen.
 
 
 ## Abgabe

--- a/docs/project/requirements.md
+++ b/docs/project/requirements.md
@@ -14,7 +14,7 @@ Kopieren Sie das [Pflichtenheft Markdown Template](https://raw.githubusercontent
 
 ### Einleitung und allgemeine Beschreibung
 
-Schauen Sie sich die Theorie zum Thema [Anforderungsanalyse](../../week6) nochmals genau an. Überlegen Sie sich wer ihre Stakeholder sind und wie diese von den Änderungen betroffen sind. Schauen Sie sich die nachfolgenden Beispiele für Pflichtenhefte an:
+Schauen Sie sich die Theorie zum Thema [Anforderungsanalyse](../week6) nochmals genau an. Überlegen Sie sich wer ihre Stakeholder sind und wie diese von den Änderungen betroffen sind. Schauen Sie sich die nachfolgenden Beispiele für Pflichtenhefte an:
 
 * [Beispiel früheres Projekt](https://adam.unibas.ch/goto_adam_file_1480294_download.html)
 * [Beispiel nach Lehrbuch von Balzert](https://adam.unibas.ch/goto_adam_file_1474955_download.html).

--- a/docs/week6/index.md
+++ b/docs/week6/index.md
@@ -21,7 +21,7 @@ In dieser Woche beginnen Sie auch offiziell mit Ihrem Projekt. Sie werden die An
 * Schritt 4: Schauen Sie sich das Beispiel: Pflichtenheft / Lastenheft an ([Artikel](./pflichtenheft2))
 * Schritt 5: Lesen Sie den Artikel "Anforderungen mit Sprachschablonen formulieren" ([Artikel](./language-templates))
 * Schritt 6: Lesen Sie den Artikel "Anforderungen mithilfe von Use Cases ermitteln" ([Artikel](./use-cases))
-* Schritt 7: Bearbeiten Sie den Test. ([(Adam)](https://adam.unibas.ch/goto_adam_tst_1629489.html)).
+* Schritt 7: Bearbeiten Sie den Test. ([Adam](https://adam.unibas.ch/goto_adam_tst_1629489.html)).
 
 #### Präsenzveranstaltung vom 25. Oktober
 

--- a/docs/week6/language-templates.md
+++ b/docs/week6/language-templates.md
@@ -22,6 +22,6 @@ Wir beginnen also unsere Sätze immer mit dem Wort *Das System* oder *Die Kompon
  Beispiele von so definierten Anforderungen sind:
 * Das System muss dem Kunden die M&ouml;glichkeit bieten, Geld zu beziehen
 * Das System muss ein Aktivit&auml;tsjournal f&uuml;hren.
-* Die Konsole sollte dem Benutzer verst&auml;ndliche Fehlermeldungen ausgeben. Viele weitere Beispiele finden Sie im Beispiel Pflichtenheft auf dem [Adam workspace](https://adam.unibas.ch/goto_adam_file_732351_download.html).
+* Die Konsole sollte dem Benutzer verst&auml;ndliche Fehlermeldungen ausgeben. Viele weitere Beispiele finden Sie im Beispiel Pflichtenheft auf dem [Adam workspace](https://adam.unibas.ch/goto_adam_file_1629482.html).
                         
 *Achtung: Sprachschablonen sind keine Formalen Spezifikationen. Sie sind lediglich eine Hilfe, um Anforderungen etwas präziser zu formulieren und sie leicht lesbar zu machen. Sie haben aber noch immer alle Vor-und Nachteile, die natürlichsprachige Anforderungen mit sich bringen.*


### PR DESCRIPTION
CHANGES:
- Typos und veraltete Links Korrekturen für Material von Woche 6

DONE:
- Material von Woche 6 durchgelesen/angeschaut, Links getestet
- Selbsttest Woche 6

BEMERKUNGEN:
- Gewisse Unterlagen für Woche 6 sind zwar im Repo, scheinen aber auf der Seite zu fehlen:
    - https://unibas-marcelluethi.github.io/software-engineering/week6/pflichtenheft-example
    - Balzert Requirements: https://adam.unibas.ch/goto_adam_file_1629484.html (unter anderem relevant für den Selbsttest 6)
- Link zum Selbsttest ([Woche 6](https://unibas-marcelluethi.github.io/software-engineering-draft/week6/): Schritt 7) verweist auf den Selbsttest für die Tutoren. Ich weiss nicht ob das von ADAM automatisch geregelt wird, eventuell müsste man das noch anpassen.